### PR TITLE
Update the version that check you can use ```_get_default_root``` to Python3.9.2rc1

### DIFF
--- a/sv_ttk/__init__.py
+++ b/sv_ttk/__init__.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 def get_default_root() -> tkinter.Misc:
     if sys.version_info >= (3, 9, 2): 
-        # LOL, _get_default_root function was added in python 3.9.2
+        # _get_default_root function was added in python 3.9.2
         return tkinter._get_default_root()
     else:
         try:

--- a/sv_ttk/__init__.py
+++ b/sv_ttk/__init__.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 
 def get_default_root() -> tkinter.Misc:
-    if sys.version_info >= (3, 10): # Python 3.10.0 added _get_default_root() function
+    if sys.version_info >= (3, 9, 2): 
+        # LOL, _get_default_root function was added in python 3.9.2
         return tkinter._get_default_root()
     else:
         try:

--- a/sv_ttk/__init__.py
+++ b/sv_ttk/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 
 def get_default_root() -> tkinter.Misc:
-    if sys.version_info >= (3, 8):
+    if sys.version_info >= (3, 10): # Python 3.10.0 added _get_default_root() function
         return tkinter._get_default_root()
     else:
         try:

--- a/sv_ttk/__init__.py
+++ b/sv_ttk/__init__.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 
 def get_default_root() -> tkinter.Misc:
-    if sys.version_info >= (3, 9, 2): 
-        # _get_default_root function was added in python 3.9.2
+    if sys.version_info >= (3, 9, 2, 'rc', 1): 
+        # _get_default_root function was added in python 3.9.2 rc1
         return tkinter._get_default_root()
     else:
         try:

--- a/sv_ttk/__init__.py
+++ b/sv_ttk/__init__.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 
 def get_default_root() -> tkinter.Misc:
-    if sys.version_info >= (3, 9, 2, 'rc', 1): 
-        # _get_default_root function was added in python 3.9.2 rc1
+    if sys.version_info >= (3, 9, 2): 
+        # _get_default_root function was added in python 3.9.2
         return tkinter._get_default_root()
     else:
         try:


### PR DESCRIPTION
![image](https://github.com/rdbende/Sun-Valley-ttk-theme/assets/71159641/72e58d30-d8bb-4715-846c-71302332d472)

Because I searched the tags in the cpython repo and I found the ```_get_default_root``` 
was created in Python3.9.2rc1. So I changed the version number to Python 3.9.2 rc1
```python
(3, 9, 2, 'rc', 1)
```
fix #98 