### PR TITLE
Add py.typed marker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=["sv_ttk"],
-    package_data={"sv_ttk": ["sv.tcl", "theme/*"]},
+    package_data={"sv_ttk": ["sv.tcl", "theme/*", "py.typed"]},
     python_requires=">=3.7",
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
This makes mypy look at this project's `.py` files, so that you don't need to add a `# type: ignore` when importing `sv_ttk`, and mypy actually checks things when you use `sv_ttk`.

Tested manually:

![s](https://github.com/rdbende/Sun-Valley-ttk-theme/assets/18505570/0b07459b-c09c-4dda-bf50-7dfc50548f55)
