### PR TITLE
Windows title bar tweaks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     description="A gorgeous theme for Tkinter, based on Windows 11's UI",
     long_description=long_description,
     long_description_content_type="text/markdown",
+    requires=["pywinstyles"],
     packages=["sv_ttk"],
     package_data={"sv_ttk": ["sv.tcl", "theme/*", "py.typed"]},
     python_requires=">=3.8",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     description="A gorgeous theme for Tkinter, based on Windows 11's UI",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    requires=["pywinstyles"],
+    install_requires=["pywinstyles"],
     packages=["sv_ttk"],
     package_data={"sv_ttk": ["sv.tcl", "theme/*", "py.typed"]},
     python_requires=">=3.8",

--- a/sv_ttk/__init__.py
+++ b/sv_ttk/__init__.py
@@ -37,11 +37,17 @@ def set_theme(theme: str, root: tkinter.Tk | None = None) -> None:
 
     # Set the title bar color on Windows
     if get_windows_version() == 10:
-        if theme == "dark": pywinstyles.apply_style(root, "dark")
-        else: pywinstyles.apply_style(root, "normal")
+        if theme == "dark": pywinstyles.apply_style(style.master, "dark")
+        else: pywinstyles.apply_style(style.master, "normal")
+
+        # A hacky way to update the title bar's color on Windows 10 (it doesn't update instantly like on Windows 11)
+        style.master.wm_attributes("-alpha", 0)
+        style.master.iconify()
+        style.master.deiconify()
+        style.master.wm_attributes("-alpha", 1)
     elif get_windows_version() == 11:
-        if theme == "dark": pywinstyles.change_header_color(root, "#1c1c1c")
-        elif theme == "light": pywinstyles.change_header_color(root, "#fafafa")
+        if theme == "dark": pywinstyles.change_header_color(style.master, "#1c1c1c")
+        elif theme == "light": pywinstyles.change_header_color(style.master, "#fafafa")
 
     style.theme_use(f"sun-valley-{theme}")
 
@@ -50,7 +56,6 @@ def toggle_theme(root: tkinter.Tk | None = None) -> None:
     _load_theme(style)
 
     set_theme("light" if style.theme_use() == "sun-valley-dark" else "dark")
-
 
 def get_windows_version() -> int:
     if platform.system() == "Windows":

--- a/sv_ttk/__init__.py
+++ b/sv_ttk/__init__.py
@@ -35,21 +35,28 @@ def set_theme(theme: str, root: tkinter.Tk | None = None) -> None:
     if theme not in {"dark", "light"}:
         raise RuntimeError(f"not a valid sv_ttk theme: {theme}")
 
-    # Set the title bar color on Windows
-    if get_windows_version() == 10:
-        if theme == "dark": pywinstyles.apply_style(style.master, "dark")
-        else: pywinstyles.apply_style(style.master, "normal")
+    # Set title bar color on Windows
+    def set_title_bar_color(root):
+        if get_windows_version() == 10:
+            if theme == "dark": pywinstyles.apply_style(root, "dark")
+            else: pywinstyles.apply_style(root, "normal")
 
-        # A hacky way to update the title bar's color on Windows 10 (it doesn't update instantly like on Windows 11)
-        if style.master.state() == "normal":
-            style.master.state("zoomed")
-            style.master.state("normal")
-        elif style.master.state() == "zoomed":
-            style.master.state("normal")
-            style.master.state("zoomed")
-    elif get_windows_version() == 11:
-        if theme == "dark": pywinstyles.change_header_color(style.master, "#1c1c1c")
-        elif theme == "light": pywinstyles.change_header_color(style.master, "#fafafa")
+            # A hacky way to update the title bar's color on Windows 10 (it doesn't update instantly like on Windows 11)
+            if root.state() == "normal":
+                root.state("zoomed")
+                root.state("normal")
+            elif root.state() == "zoomed":
+                root.state("normal")
+                root.state("zoomed")
+        elif get_windows_version() == 11:
+            if theme == "dark": pywinstyles.change_header_color(root, "#1c1c1c")
+            elif theme == "light": pywinstyles.change_header_color(root, "#fafafa")
+
+    set_title_bar_color(style.master)
+
+    # Set the title bar color of Toplevels too
+    for widget in style.master.winfo_children():
+        if isinstance(widget, tkinter.Toplevel): set_title_bar_color(widget)
 
     style.theme_use(f"sun-valley-{theme}")
 

--- a/sv_ttk/__init__.py
+++ b/sv_ttk/__init__.py
@@ -9,6 +9,17 @@ import sys
 TCL_THEME_FILE_PATH = Path(__file__).with_name("sv.tcl").absolute()
 
 
+# A hacky way to change a Toplevel's title bar color after it's created
+class ThemedToplevel(tkinter.Toplevel):
+    def __init__(self, master=None, *args, **kwargs):
+        super().__init__(master, *args, **kwargs)
+
+        try: set_theme(get_theme())
+        except: pass
+
+tkinter.Toplevel = ThemedToplevel
+
+
 def _load_theme(style: ttk.Style) -> None:
     if not isinstance(style.master, tkinter.Tk):
         raise TypeError("root must be a `tkinter.Tk` instance!")
@@ -39,28 +50,25 @@ def set_theme(theme: str, root: tkinter.Tk | None = None) -> None:
     def set_title_bar_color(root):
         if get_windows_version() == 10:
             import pywinstyles
-            
+
             if theme == "dark": pywinstyles.apply_style(root, "dark")
             else: pywinstyles.apply_style(root, "normal")
 
             # A hacky way to update the title bar's color on Windows 10 (it doesn't update instantly like on Windows 11)
-            if root.state() == "normal":
-                root.state("zoomed")
-                root.state("normal")
-            elif root.state() == "zoomed":
-                root.state("normal")
-                root.state("zoomed")
+            root.wm_attributes("-alpha", 0.99)
+            root.wm_attributes("-alpha", 1)
         elif get_windows_version() == 11:
             import pywinstyles
             
             if theme == "dark": pywinstyles.change_header_color(root, "#1c1c1c")
             elif theme == "light": pywinstyles.change_header_color(root, "#fafafa")
 
-    set_title_bar_color(style.master)
+    def set_title_bar_color_toplevels():
+        for widget in style.master.winfo_children():
+            if isinstance(widget, tkinter.Toplevel): set_title_bar_color(widget)
 
-    # Set the title bar color of Toplevels too
-    for widget in style.master.winfo_children():
-        if isinstance(widget, tkinter.Toplevel): set_title_bar_color(widget)
+    set_title_bar_color(style.master)
+    set_title_bar_color_toplevels()
 
     style.theme_use(f"sun-valley-{theme}")
 

--- a/sv_ttk/__init__.py
+++ b/sv_ttk/__init__.py
@@ -4,7 +4,7 @@ import tkinter
 from functools import partial
 from pathlib import Path
 from tkinter import ttk
-import platform, sys, pywinstyles
+import sys, pywinstyles
 
 TCL_THEME_FILE_PATH = Path(__file__).with_name("sv.tcl").absolute()
 
@@ -41,15 +41,18 @@ def set_theme(theme: str, root: tkinter.Tk | None = None) -> None:
         else: pywinstyles.apply_style(style.master, "normal")
 
         # A hacky way to update the title bar's color on Windows 10 (it doesn't update instantly like on Windows 11)
-        style.master.wm_attributes("-alpha", 0)
-        style.master.iconify()
-        style.master.deiconify()
-        style.master.wm_attributes("-alpha", 1)
+        if style.master.state() == "normal":
+            style.master.state("zoomed")
+            style.master.state("normal")
+        elif style.master.state() == "zoomed":
+            style.master.state("normal")
+            style.master.state("zoomed")
     elif get_windows_version() == 11:
         if theme == "dark": pywinstyles.change_header_color(style.master, "#1c1c1c")
         elif theme == "light": pywinstyles.change_header_color(style.master, "#fafafa")
 
     style.theme_use(f"sun-valley-{theme}")
+
 
 def toggle_theme(root: tkinter.Tk | None = None) -> None:
     style = ttk.Style(master=root)
@@ -57,8 +60,9 @@ def toggle_theme(root: tkinter.Tk | None = None) -> None:
 
     set_theme("light" if style.theme_use() == "sun-valley-dark" else "dark")
 
+
 def get_windows_version() -> int:
-    if platform.system() == "Windows":
+    if sys.platform == "win32":
         # Running on Windows
         version = sys.getwindowsversion()
 

--- a/sv_ttk/__init__.py
+++ b/sv_ttk/__init__.py
@@ -4,6 +4,7 @@ import tkinter
 from functools import partial
 from pathlib import Path
 from tkinter import ttk
+import platform, sys, pywinstyles
 
 TCL_THEME_FILE_PATH = Path(__file__).with_name("sv.tcl").absolute()
 
@@ -34,8 +35,15 @@ def set_theme(theme: str, root: tkinter.Tk | None = None) -> None:
     if theme not in {"dark", "light"}:
         raise RuntimeError(f"not a valid sv_ttk theme: {theme}")
 
-    style.theme_use(f"sun-valley-{theme}")
+    # Set the title bar color on Windows
+    if get_windows_version() == 10:
+        if theme == "dark": pywinstyles.apply_style(root, "dark")
+        else: pywinstyles.apply_style(root, "normal")
+    elif get_windows_version() == 11:
+        if theme == "dark": pywinstyles.change_header_color(root, "#1c1c1c")
+        elif theme == "light": pywinstyles.change_header_color(root, "#fafafa")
 
+    style.theme_use(f"sun-valley-{theme}")
 
 def toggle_theme(root: tkinter.Tk | None = None) -> None:
     style = ttk.Style(master=root)
@@ -43,6 +51,24 @@ def toggle_theme(root: tkinter.Tk | None = None) -> None:
 
     set_theme("light" if style.theme_use() == "sun-valley-dark" else "dark")
 
+
+def get_windows_version() -> int:
+    if platform.system() == "Windows":
+        # Running on Windows
+        version = sys.getwindowsversion()
+
+        if version.major == 10 and version.build >= 22000:
+            # Windows 11
+            return 11
+        elif version.major == 10:
+            # Windows 10
+            return 10
+        else:
+            # Other Windows version (like 7, 8, 8.1, etc...)
+            return version.major
+    else:
+        # Not running on Windows
+        return 0
 
 use_dark_theme = partial(set_theme, "dark")
 use_light_theme = partial(set_theme, "light")

--- a/sv_ttk/__init__.py
+++ b/sv_ttk/__init__.py
@@ -4,7 +4,7 @@ import tkinter
 from functools import partial
 from pathlib import Path
 from tkinter import ttk
-import sys, pywinstyles
+import sys
 
 TCL_THEME_FILE_PATH = Path(__file__).with_name("sv.tcl").absolute()
 
@@ -38,6 +38,8 @@ def set_theme(theme: str, root: tkinter.Tk | None = None) -> None:
     # Set title bar color on Windows
     def set_title_bar_color(root):
         if get_windows_version() == 10:
+            import pywinstyles
+            
             if theme == "dark": pywinstyles.apply_style(root, "dark")
             else: pywinstyles.apply_style(root, "normal")
 
@@ -49,6 +51,8 @@ def set_theme(theme: str, root: tkinter.Tk | None = None) -> None:
                 root.state("normal")
                 root.state("zoomed")
         elif get_windows_version() == 11:
+            import pywinstyles
+            
             if theme == "dark": pywinstyles.change_header_color(root, "#1c1c1c")
             elif theme == "light": pywinstyles.change_header_color(root, "#fafafa")
 


### PR DESCRIPTION
Hi! In this PR I made sv_ttk change the color of the title bar to match the light or dark theme on Windows. Here are some screenshots:

Windows 11 Light

![w11-light](https://github.com/rdbende/Sun-Valley-ttk-theme/assets/122545522/24d3e953-4e96-4a07-8488-e4516408eba7)

Windows 11 Dark

![w11-dark](https://github.com/rdbende/Sun-Valley-ttk-theme/assets/122545522/81ecda12-9a45-44ad-81e4-eab394705e1f)

Windows 10 Light

![win10_light](https://github.com/rdbende/Sun-Valley-ttk-theme/assets/122545522/e641b2f6-6528-491c-b246-021d8efef8a4)

Windows 10 Dark

![win10_dark](https://github.com/rdbende/Sun-Valley-ttk-theme/assets/122545522/f2a24b6e-6d5e-4c96-aaa5-fa8a36de7474)

Due to Windows 10 limitations, you can't set a custom title bar color. Instead, it can only be set to black in dark mode and white in light mode. On Windows 11 you can set its color to any color.

I made this PR also change the Toplevel windows' title bar color. Here are some screen recordings:

https://github.com/rdbende/Sun-Valley-ttk-theme/assets/122545522/4aa422f1-6db3-4c3c-b4e7-aa37ad09634d

https://github.com/rdbende/Sun-Valley-ttk-theme/assets/122545522/d1b3b9d7-f042-4047-8027-a91aefc599fc