### PR TITLE
Make scrollbars less width

### DIFF
--- a/sv_ttk/theme/dark.tcl
+++ b/sv_ttk/theme/dark.tcl
@@ -375,14 +375,14 @@ namespace eval ttk::theme::sv_dark {
       }
     }
 
-    ttk::style element create Horizontal.Scrollbar.trough image $I(scrollbar-trough-hor) -sticky ew -border 6
-    ttk::style element create Horizontal.Scrollbar.thumb image $I(scrollbar-thumb-hor) -sticky ew -border 3
+    ttk::style element create Horizontal.Scrollbar.trough image $I(scrollbar-trough-hor) -sticky ew -border {6 0}
+    ttk::style element create Horizontal.Scrollbar.thumb image $I(scrollbar-thumb-hor) -sticky ew -border {3 0}
 
     ttk::style element create Horizontal.Scrollbar.rightarrow image $I(scrollbar-right) -sticky e -width 13
     ttk::style element create Horizontal.Scrollbar.leftarrow image $I(scrollbar-left) -sticky w -width 13
 
-    ttk::style element create Vertical.Scrollbar.trough image $I(scrollbar-trough-vert) -sticky ns -border 6
-    ttk::style element create Vertical.Scrollbar.thumb image $I(scrollbar-thumb-vert) -sticky ns -border 3
+    ttk::style element create Vertical.Scrollbar.trough image $I(scrollbar-trough-vert) -sticky ns -border {0 6}
+    ttk::style element create Vertical.Scrollbar.thumb image $I(scrollbar-thumb-vert) -sticky ns -border {0 3}
 
     ttk::style element create Vertical.Scrollbar.uparrow image $I(scrollbar-up) -sticky n -height 13
     ttk::style element create Vertical.Scrollbar.downarrow image $I(scrollbar-down) -sticky s -height 13

--- a/sv_ttk/theme/light.tcl
+++ b/sv_ttk/theme/light.tcl
@@ -380,14 +380,14 @@ namespace eval ttk::theme::sv_light {
       }
     }
 
-    ttk::style element create Horizontal.Scrollbar.trough image $I(scrollbar-trough-hor) -sticky ew -border 6
-    ttk::style element create Horizontal.Scrollbar.thumb image $I(scrollbar-thumb-hor) -sticky ew -border 3
+    ttk::style element create Horizontal.Scrollbar.trough image $I(scrollbar-trough-hor) -sticky ew -border {6 0}
+    ttk::style element create Horizontal.Scrollbar.thumb image $I(scrollbar-thumb-hor) -sticky ew -border {3 0}
 
     ttk::style element create Horizontal.Scrollbar.rightarrow image $I(scrollbar-right) -sticky e -width 13
     ttk::style element create Horizontal.Scrollbar.leftarrow image $I(scrollbar-left) -sticky w -width 13
 
-    ttk::style element create Vertical.Scrollbar.trough image $I(scrollbar-trough-vert) -sticky ns -border 6
-    ttk::style element create Vertical.Scrollbar.thumb image $I(scrollbar-thumb-vert) -sticky ns -border 3
+    ttk::style element create Vertical.Scrollbar.trough image $I(scrollbar-trough-vert) -sticky ns -border {0 6}
+    ttk::style element create Vertical.Scrollbar.thumb image $I(scrollbar-thumb-vert) -sticky ns -border {0 3}
 
     ttk::style element create Vertical.Scrollbar.uparrow image $I(scrollbar-up) -sticky n -height 13
     ttk::style element create Vertical.Scrollbar.downarrow image $I(scrollbar-down) -sticky s -height 13


### PR DESCRIPTION
## Introduction

Remove unnecessary margins from the scrollbar and make the scrollbar smaller in width to create a more compact UI.

In fact, the scrollbar itself in Windows 11 takes up very little space.

## Screenshots

| Before | After |
| - | - |
| <img width="657" alt="Snipaste_2025-06-06_02-35-21" src="https://github.com/user-attachments/assets/c69b4d5c-4b37-4dae-8de6-3a2865ea9a52" /> | <img width="639" alt="Snipaste_2025-06-06_02-29-37" src="https://github.com/user-attachments/assets/bdf48c25-a9ba-441c-888e-6e897f2e8d60" /> |
| <img width="657" alt="Snipaste_2025-06-06_02-37-54" src="https://github.com/user-attachments/assets/cae0537c-0696-490a-aa0b-0544f2d839d4" /> | <img width="648" alt="Snipaste_2025-06-06_02-36-54" src="https://github.com/user-attachments/assets/0d849d42-4586-45de-9d97-9521f915a3e6" /> |
