### PR TITLE
Fix menu colors on Windows

### DIFF
--- a/sv_ttk/sv.tcl
+++ b/sv_ttk/sv.tcl
@@ -67,6 +67,21 @@ proc config_menus {w} {
 }
 
 
+proc fix_menus_on_windows {root} {
+ foreach w [winfo children $root] {
+    if {[winfo class $w] eq "Menu"} {
+      $w configure \
+        -background "SystemMenu" \
+        -foreground "SystemMenuText" \
+        -activebackground "SystemHighlight" \
+        -activeforeground "SystemHighlightText"
+    } else {
+      fix_menus_on_windows $w
+    }
+  } 
+}
+
+
 proc configure_colors {} {
   set theme [ttk::style theme use]
   if {$theme == "sun-valley-dark"} {
@@ -119,6 +134,10 @@ proc configure_colors {} {
       activeForeground $ttk::theme::sv_light::colors(-selfg)
 
     ttk::style map . -foreground [list disabled $ttk::theme::sv_light::colors(-disfg)]
+  }
+
+  if {[tk windowingsystem] == "win32"} {
+    fix_menus_on_windows .
   }
 }
 


### PR DESCRIPTION
#126 was supposed to make the theme not change the menus' colors on Windows, but unfortunately the fix doesn't work. This is because `tk_setPalette` also affects menus and that fix just prevented the menus to not get the theme's menu-specific colors. For fixing them, we can set their background color to `SystemMenu` and their foreground to `SystemMenuText`. Unfortunately, for some reason, the menus don't respond to the `<<ThemeChanged>>` event on Windows unless they're displayed at least once. The best solution I could came with was to find menus recursively and style them accordingly in the `configure_colors` procedure.